### PR TITLE
Apply hypermodern template to project

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "locatieserver"
-version = "0.5.4"
+version = "0.6.0"
 description = "Locatieserver"
 authors = ["Jelmer Draaijer <info@jelmert.nl>"]
 license = "MIT"


### PR DESCRIPTION
This PR moves away from [cookietemplate](https://github.com/cookiejar/cookietemple) and implements the [cookiecutter-hypermodern-python](https://github.com/cjolowicz/cookiecutter-hypermodern-python) project.