### PR TITLE
Remove safety from github actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,6 @@ jobs:
       matrix:
         include:
           - { python: "3.11", os: "ubuntu-latest", session: "pre-commit" }
-          - { python: "3.11", os: "ubuntu-latest", session: "safety" }
           - { python: "3.12", os: "ubuntu-latest", session: "mypy" }
           - { python: "3.11", os: "ubuntu-latest", session: "mypy" }
           - { python: "3.10", os: "ubuntu-latest", session: "mypy" }


### PR DESCRIPTION
Safety almost always fails and the issues it raises cannot be solved from our side. Removing `safety` restores the trust in the the outcomes.


Committed via https://github.com/asottile/all-repos